### PR TITLE
updates comment_count_by_month method to query a comment's 'created_a…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'validates_timeliness', '~> 4.0'
 gem 'jquery-turbolinks'
 gem 'ahoy_matey'
   gem 'activeuuid', '>= 0.5.0'
+gem 'whenever', :require => false
 
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       debugger-linecache (~> 1.2)
       slop (~> 3.6)
     choice (0.2.0)
+    chronic (0.10.2)
     coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -242,6 +243,8 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
     will_paginate (3.1.0)
     yaml_db (0.3.0)
       rails (>= 3.0, < 4.3)
@@ -280,6 +283,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   validates_timeliness (~> 4.0)
   web-console (~> 2.0)
+  whenever
   will_paginate
   yaml_db
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -147,10 +147,10 @@ class User < ActiveRecord::Base
 	def comment_count_by_month(month)
 		if Rails.env.development?
 			#SQLite database queries (local development environment) need to use 'strftime()' to grab info from datetimes
-			self.comments.where("strftime('%m', date)+0 = ?", month).count
+			self.comments.where("strftime('%m', created_at)+0 = ?", month).count
 		elsif Rails.env.production?
 			#Postgres database queries (remote Heroku production enviroment) need to use 'extract' to grab info from datetimes
-			self.comments.where('extract(month from date) = ?', month).count
+			self.comments.where('extract(month from created_at) = ?', month).count
 		end
 	end
 
@@ -205,19 +205,6 @@ class User < ActiveRecord::Base
 		User.all_non_admin_user_names_with_comment_count_by_month(month).sort_by do |user, comment_count| 
 			[-(comment_count), -(User.find_by_user_name(user).comments_word_count_by_month(month).to_i)]
 		end[0..(limit-1)].to_h
-	end	
-
-
-	#Community user data...
-	def self.community_user_data
-		User.all.each_with_object({}) do |user, hash| 
-			if !user.admin? && user.activated? 
-				hash[user.user_name] = 	{ :member_since => user.activated_at, 
-																	:comment_count => user.comments.count,
-																	:comments_word_count => user.all_comments_word_count
-															 	}
-			end
-		end
 	end
 	
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,20 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever


### PR DESCRIPTION
…t' instead of 'date' column because 'created-at' is indexed and improves speed